### PR TITLE
docs(readme): add Go REST-APIs framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Contributions are most welcome. Categories are also open to suggestions!
 - [Goat](https://github.com/bahlo/goat): Minimalistic REST API server in Go.
 - [Resoursea](https://github.com/resoursea/api): REST framework for quickly writing resource based services.
 - [Zerver](https://github.com/cosiner/zerver): Zerver is a expressive, modular, feature completed RESTful framework.
+- [Fibre](https://github.com/gofiber/fiber): :zap:Fiber is an Express inspired web framework written in Go with :coffee: .
 
 ### Scala
 - [Colossus](https://github.com/tumblr/colossus): I/O and microservice library for Scala.


### PR DESCRIPTION
 - :zap: Fiber is an Express inspired web framework built on top of [Fasthttp](https://github.com/valyala/fasthttp), the fastest HTTP engine for [Go](https://golang.org/doc/). 
 - Designed to ease things up for fast development with zero memory allocation and performance in mind.