### PR TITLE
Add Agent Gateway to API Gateways section

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Contributions are most welcome. Categories are also open to suggestions!
 - [Traefik](https://github.com/containous/traefik): Træfik (pronounced like traffic) is a modern HTTP reverse proxy and load balancer written in Go.
 - [Oathkeeper](https://github.com/ory/oathkeeper): OIdentity & Access Proxy (IAP) that authorizes HTTP requests based on sets of rules. Integrates with ORY Hydra.
 - [Zuplo](https://zuplo.com/): OpenAPI-Powered API Management platform for API Development, Deployment, and Documentation. Add auth, rate-limiting, and monetization to your API in minutes.
+- [Agent Gateway](https://agent-gateway-kappa.vercel.app): One API key for 34+ AI agent infrastructure services with OpenAPI specs and agent.json discovery.
 
 ## API Security
 - [Online OpenAPI/Swagger File Security Audit](https://apisecurity.io/tools/audit/): Free online static analysis of API contract files. Upload the file and get the report.


### PR DESCRIPTION
## Summary

Adds [Agent Gateway](https://agent-gateway-kappa.vercel.app) to the **API Gateways** section.

Agent Gateway provides one API key for 34+ AI agent infrastructure services with OpenAPI specs and agent.json discovery. Services include memory, wallets, code execution, scheduling, webhooks, scraping, and more.

- **URL**: https://agent-gateway-kappa.vercel.app
- **Docs**: https://agent-gateway-kappa.vercel.app/docs