### PR TITLE
Add Sourcey to API Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Contributions are most welcome. Categories are also open to suggestions!
 - [API Docs](https://api-docs.io/): Hosted public API documentation for OAS (Swagger) and RAML specs.
 - [Docbox](https://github.com/tmcw/docbox): REST API documentation generator, using Markdown.
 - [widdershins](https://github.com/Mermade/widdershins): REST API documentation generator from OpenAPI 3.0 / Swagger 2.0 / AsyncAPI 1.x / Semoasa 0.1.0 definition
-- [Sourcey](https://github.com/sourcey/sourcey): Multi-source static documentation generator. OpenAPI, MCP, Doxygen XML, godoc, and Markdown into one static HTML site. Self-hosted, AGPL-3.0.
+- [Sourcey](https://sourcey.com): Multi-source static documentation generator. OpenAPI, MCP, Doxygen XML, godoc, and Markdown into one static HTML site. Self-hosted, AGPL-3.0.
 - [Elements](https://github.com/stoplightio/elements): Web Components-based API documentation for OpenAPI 3.x/2.x
 
 ## API Clients

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Contributions are most welcome. Categories are also open to suggestions!
 - [API Docs](https://api-docs.io/): Hosted public API documentation for OAS (Swagger) and RAML specs.
 - [Docbox](https://github.com/tmcw/docbox): REST API documentation generator, using Markdown.
 - [widdershins](https://github.com/Mermade/widdershins): REST API documentation generator from OpenAPI 3.0 / Swagger 2.0 / AsyncAPI 1.x / Semoasa 0.1.0 definition
+- [Sourcey](https://github.com/sourcey/sourcey): Multi-source static documentation generator. OpenAPI, MCP, Doxygen XML, godoc, and Markdown into one static HTML site. Self-hosted, AGPL-3.0.
 - [Elements](https://github.com/stoplightio/elements): Web Components-based API documentation for OpenAPI 3.x/2.x
 
 ## API Clients


### PR DESCRIPTION
Sourcey (https://sourcey.com) is an open-source static documentation generator that handles OpenAPI natively alongside MCP server manifests, Doxygen XML, godoc, and Markdown. Self-hosted, AGPL-3.0 on the CLI, multi-source from a single config.

Fits the API Documentation section alongside Slate, Docbox, widdershins, and ReDoc.

- Project: https://sourcey.com
- Live demo: https://sourcey.com/cheesestore
- Source: https://github.com/sourcey/sourcey