### PR TITLE
Add Specmatic to API Testing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ Contributions are most welcome. Categories are also open to suggestions!
 - [Pyresttest](https://github.com/svanoort/pyresttest): YAML based REST testing and API microbenchmarking tool
 - [OWASP Zaproxy](https://github.com/zaproxy/zaproxy): A tool to test your API for known security vulnerabilities, with a great CI integration.
 - [RestQA](https://github.com/restqa/restqa): Microservice API Testing tool focused on providing a great developer experience.
+- [Specmatic](https://specmatic.io/): An AI-powered API development suite for Contract-Driven Development that transforms specifications into executable contracts.
 - [Optic CI](https://www.useoptic.com/docs/diff-openapi): Test for breaking API changes in CI Pipelines
 
 ## API Developer Portal

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Contributions are most welcome. Categories are also open to suggestions!
 - [Pyresttest](https://github.com/svanoort/pyresttest): YAML based REST testing and API microbenchmarking tool
 - [OWASP Zaproxy](https://github.com/zaproxy/zaproxy): A tool to test your API for known security vulnerabilities, with a great CI integration.
 - [RestQA](https://github.com/restqa/restqa): Microservice API Testing tool focused on providing a great developer experience.
-- [Specmatic](https://specmatic.io/): An AI-powered API development suite for Contract-Driven Development that transforms specifications into executable contracts.
+- [Specmatic](https://specmatic.io/): An open source contract testing tool that allows developers to turn API specifications (such as OpenAPI or AsyncAPI) into executable specifications.
 - [Optic CI](https://www.useoptic.com/docs/diff-openapi): Test for breaking API changes in CI Pipelines
 
 ## API Developer Portal


### PR DESCRIPTION
Hello! 

This PR adds [Specmatic](https://specmatic.io/) to the **API Testing** section of the list.

Specmatic is an open source contract testing tool that allows developers to turn API specifications (such as OpenAPI or AsyncAPI) into executable specifications. It's highly relevant to this repository as it streamlines HTTP API development by helping teams practice Contract-Driven Development and safely mock dependencies.

I've ensured the entry is added in alphabetical order to stay consistent with the surrounding items.

Thanks for curating such a great collection of tools!
